### PR TITLE
Stop using Git-controlled file to save credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Please see [go.mod](https://github.com/tosh223/rfa/blob/main/go.mod).
         "access_token": "****************",
         "access_token_secret": "****************"
     }
+    $ cp ./secret/twitter{_example,}.json  # then replace the values with your actual ones.
 
-    $ gcloud secrets create rfa --data-file=./secret/twitter_example.json
+    $ gcloud secrets create rfa --data-file=./secret/twitter.json
     ```
 
 - Create `rfa` dataset in Google BigQuery

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please see [go.mod](https://github.com/tosh223/rfa/blob/main/go.mod).
 
 ## Usage
 
-- Regist Twitter developer secrets to Cloud Secret Manager as `rfa`
+- Register Twitter developer secrets to Cloud Secret Manager as `rfa`
 
     ```sh
     $ cat ./secret/twitter_example.json


### PR DESCRIPTION
IMHO, users should make a new copy of `secret/twitter_example.json` and use it for the `gcloud secrets` command to avoid accidental commit/push of their credentials to public network. Therefore I modified the README accordingly.

P.S. I came up with the idea of developing a similar web app (i.e., visualize RFA result using Twitter and ML-based text recognition) and set up a repository, but I found that there exists this project already. Thanks so much for your work!